### PR TITLE
Fix - implement curry() with placeholder support - Implementation 2

### DIFF
--- a/problem/implement-curry-with-placeholder_en.md
+++ b/problem/implement-curry-with-placeholder_en.md
@@ -280,7 +280,7 @@ curry.placeholder = Symbol()
 
 function mergeArgs(argsTo, argsFrom, placeholder) {
   const mappedArgsTo = argsTo.map((item) =>
-    item === placeholder ? argsFrom.shift() : item
+    item === placeholder && argsFrom.length ? argsFrom.shift() : item
   )
   return [...mappedArgsTo, ...argsFrom]
 }
@@ -310,7 +310,7 @@ function curry(fn) {
     // otherwise return a function which merges the args
     return function (...nextArgs) {
       const mappedArgsTo = args.map((item) =>
-        item === curry.placeholder ? nextArgs.shift() : item
+        item === curry.placeholder && nextArgs.length ? nextArgs.shift() : item
       )
       return curried.call(this, ...mappedArgsTo, ...nextArgs)
     }


### PR DESCRIPTION
## Ques
2. Implement curry() with placeholder support

## Section 
Solution -> Curry Implementation 2

## Fix
When doing the merge of arguments, replace the placeholder only till nextArgs (or argsFrom) has data. Otherwise, keep it as a placeholder. Hence, a length check is required here for `argsFrom`. Otherwise, a case like this will fail - 
```
curriedJoin(_, _, _)(1)(_, 3)(2)
```